### PR TITLE
Fixes RGB to Hex conversion bug

### DIFF
--- a/i-color.dev.js
+++ b/i-color.dev.js
@@ -482,7 +482,7 @@
 
                 for (loop in tmp) {
                     if (tmp[loop].length < 2) {
-                        tmp[loop] += tmp[loop];
+                        tmp[loop] = '0'+tmp[loop];
                     }
                 }
 


### PR DESCRIPTION
when the r value drops below '10'  -- e.g. '7', the value used to be
converted to '77', now it will be converted to '07'.
![example](https://f.cloud.github.com/assets/650595/1532390/6ba10e60-4c76-11e3-968f-2596bc3f1763.png)
